### PR TITLE
bump data explorer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
-    "@nteract/transform-dataresource": "^4.3.2",
+    "@nteract/transform-dataresource": "^5.0.0-alpha.0",
     "lodash": "^4.17.10",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",


### PR DESCRIPTION
Fixes #1 by including the latest data explorer. Transitions going on in the monorepo led to publishing all the packages with `-alpha.0`.